### PR TITLE
Update Evan Amies-Galonski email to personal address

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-7683-4592")),
     person("Kirill", "Müller", , "kirill@cynkra.com", role = "aut",
            comment = c(ORCID = "0000-0002-1416-3412")),
-    person("Evan", "Amies-Galonski", , "evan@poissonconsulting.ca", role = "aut",
+    person("Evan", "Amies-Galonski", , "evanamiesgalonski@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1096-2089")),
     person("Sebastian", "Dalgarno", , "seb@poissonconsulting.ca", role = "aut",
            comment = c(ORCID = "0000-0002-3658-4517")),


### PR DESCRIPTION
Replaces `evan@poissonconsulting.ca` (no longer an active address) with Evan's personal email `evanamiesgalonski@gmail.com` in DESCRIPTION.