### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/pkg-list.R
+++ b/R/pkg-list.R
@@ -1,38 +1,107 @@
 pkg_list <- list(
   conflicted = c("conflicted"),
   rprofile = c(
-    "devtools", "fledge", "lintr", "pkgdown", "remotes", "reprex", "rmarkdown",
-    "roxygen2md", "styler", "testthat", "usethis"
+    "devtools",
+    "fledge",
+    "lintr",
+    "pkgdown",
+    "remotes",
+    "reprex",
+    "rmarkdown",
+    "roxygen2md",
+    "styler",
+    "testthat",
+    "usethis"
   ),
   legacy = c("err", "rpdo", "plyr", "reshape2"),
   poisutils = c(
-    "poisspatial", "poisdata", "poisix", "poisplot", "poisutils", "poispalette"
+    "poisspatial",
+    "poisdata",
+    "poisix",
+    "poisplot",
+    "poisutils",
+    "poispalette"
   ),
-  bc = c("bcdata", "renmods", "wqbc", "wqindex", "fishbc", "fwapgr", "fwatlasbc"),
+  bc = c(
+    "bcdata",
+    "renmods",
+    "wqbc",
+    "wqindex",
+    "fishbc",
+    "fwapgr",
+    "fwatlasbc"
+  ),
   canada = c("canwqdata", "ssdtools"),
   parallel = c("doParallel", "foreach"),
   misc = c(
-    "data.table", "daff", "naniar", "readwriteaws", "snakecase", "sessioninfo",
-    "units", "yesno"
+    "data.table",
+    "daff",
+    "naniar",
+    "readwriteaws",
+    "snakecase",
+    "sessioninfo",
+    "units",
+    "yesno"
   ),
   spatial = c("mapview", "sf"),
   tidyverse_extras = c(
-    "blob", "cli", "crayon", "hms", "glue", "lubridate", "magrittr", "pillar",
-    "readxl", "rlang", "dm", "tidyplus"
+    "blob",
+    "cli",
+    "crayon",
+    "hms",
+    "glue",
+    "lubridate",
+    "magrittr",
+    "pillar",
+    "readxl",
+    "rlang",
+    "dm",
+    "tidyplus"
   ),
   tidyverse_core = c(
-    "ggplot2", "tibble", "tidyr", "readr", "purrr", "dplyr", "stringr",
+    "ggplot2",
+    "tibble",
+    "tidyr",
+    "readr",
+    "purrr",
+    "dplyr",
+    "stringr",
     "forcats"
   ),
   plot = c(
-    "grid", "ggplot2", "ggdag", "ggmap", "ggrepel", "ggspatial", "ggthemes",
-    "ggh4x", "latex2exp", "scales", "viridis", "tinter"
+    "grid",
+    "ggplot2",
+    "ggdag",
+    "ggmap",
+    "ggrepel",
+    "ggspatial",
+    "ggthemes",
+    "ggh4x",
+    "latex2exp",
+    "scales",
+    "viridis",
+    "tinter"
   ),
   utils = c("chk", "dttr2", "hmstimer"),
   databasing = c("flobr", "dbflobr", "RSQLite", "readwritesqlite"),
   analysis = c(
-    "universals", "extras", "ggdag", "term", "loo", "nlist", "newdata", "rescale",
-    "mcmcr", "mcmcderive", "mcmcdata", "embr", "tmbr", "smbr2", "smbr", "jmbr", "priorsense"
+    "universals",
+    "extras",
+    "ggdag",
+    "term",
+    "loo",
+    "nlist",
+    "newdata",
+    "rescale",
+    "mcmcr",
+    "mcmcderive",
+    "mcmcdata",
+    "embr",
+    "tmbr",
+    "smbr2",
+    "smbr",
+    "jmbr",
+    "priorsense"
   ),
   reporting = c("subfoldr2", "subfoldr2ext", "subreport")
 )

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)